### PR TITLE
BoardMembers&CoreTeam

### DIFF
--- a/components/team/team.scss
+++ b/components/team/team.scss
@@ -18,21 +18,3 @@
 .title {
   text-align: center;
 }
-
-@media only screen and (min-device-width: 320px) and (max-device-width: 359px) {
-  .team-members.core-team {
-    max-width: 150px;
-  }
-}
-
-@media only screen and (min-device-width: 360px) and (max-device-width: 375px) {
-  .team-members.core-team {
-    max-width: 180px;
-  }
-}
-
-@media only screen and (min-device-width: 376px) and (max-device-width: 414px) {
-  .team-members.core-team {
-    max-width: 200px;
-  }
-}

--- a/pages/about.js
+++ b/pages/about.js
@@ -9,6 +9,7 @@ import {
   title as contact_title
 } from '../components/content/_contact'
 import Contactform from '../components/contact-form/contact-form'
+import { BoardMembers, CoreTeam } from '../components/team/team'
 import Partners from '../components/partners/partners'
 import Press from '../components/partners/press'
 
@@ -44,8 +45,10 @@ export default () => (
       </div>
     </Content>
 
+    <BoardMembers />
+    <CoreTeam />
     <Press />
-
     <Partners />
+
   </Layout>
 )

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import Team from '../components/team/team'
+import { MentorsTeam } from '../components/team/team'
 import Layout from '../components/layouts/layout'
 import Content from '../components/layouts/content/content'
 import marked from 'marked'
@@ -19,7 +19,7 @@ export default () => {
       <Content>
         <div dangerouslySetInnerHTML={{ __html: marked(content) }} />
       </Content>
-      <Team />
+      <MentorsTeam />
       <Partners />
     </Layout>
   )


### PR DESCRIPTION
- Applied the logic of 2 people per row on mobile view used on Mentors.
- Moved core team and board to about page beneath the map.