### PR TITLE
cleanup: mostly to bring uniformity to spellings used by alumni for the same skills

### DIFF
--- a/components/hire/alumni.json
+++ b/components/hire/alumni.json
@@ -11,7 +11,7 @@
     "skills": ["JS", "Express.js", "MySQL", "React", "HTML", "CSS", "Node.js"],
     "status": "looking for jobs",
     "graduationDate": "02-09-2018",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 2,
@@ -25,7 +25,7 @@
     "skills": ["JS", "Express.js", "MySQL", "React", "HTML", "CSS", "Node.js"],
     "status": "employed",
     "graduationDate": "25-11-2018",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 3,
@@ -47,7 +47,6 @@
       "Node.js",
       "Java",
       "Sass",
-      "Scss",
       "Heroku",
       "Knex.js",
       "XML",
@@ -56,7 +55,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "02-06-2018",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 4,
@@ -88,7 +87,7 @@
     "status": "employed",
     "company": "SocialTechProject",
     "graduationDate": "02-06-2018",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 5,
@@ -102,7 +101,7 @@
     "status": "employed",
     "company": "Peytz & Co",
     "graduationDate": "25-11-2018",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 6,
@@ -115,7 +114,7 @@
     "skills": ["JS", "Express.js", "MySQL", "React", "HTML", "CSS", "Node.js"],
     "status": "looking for jobs",
     "graduationDate": "25-11-2018",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 7,
@@ -129,7 +128,7 @@
     "skills": ["JS", "Express.js", "MySQL", "React", "HTML", "CSS", "Node.js"],
     "status": "looking for jobs",
     "graduationDate": "02-06-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 8,
@@ -143,7 +142,7 @@
     "skills": ["JS", "Express.js", "MySQL", "React", "HTML", "CSS", "Node.js"],
     "status": "employed",
     "graduationDate": "27-01-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 9,
@@ -157,7 +156,7 @@
     "company": "Mytheresa.com",
     "status": "employed",
     "graduationDate": "27-01-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 10,
@@ -171,7 +170,7 @@
     "skills": ["JS", "Express.js", "MySQL", "React", "HTML", "CSS", "Node.js"],
     "status": "looking for jobs",
     "graduationDate": "01-09-2018",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 11,
@@ -195,7 +194,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "11-08-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 12,
@@ -225,7 +224,7 @@
     ],
     "status": "employed",
     "graduationDate": "11-06-2018",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 13,
@@ -244,11 +243,11 @@
       "HTML",
       "CSS",
       "Node.js",
-      "HighCharts/React-HighCharts"
+      "HighCharts"
     ],
     "status": "looking for jobs",
     "graduationDate": "11-08-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 14,
@@ -271,7 +270,7 @@
     "linkedin": "https://www.linkedin.com/in/nmoskaleva",
     "status": "looking for jobs",
     "graduationDate": "11-08-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 15,
@@ -295,7 +294,7 @@
     "onlineCV": "https://keerthi1822.github.io/Resume/",
     "status": "looking for jobs",
     "graduationDate": "11-08-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 16,
@@ -317,7 +316,7 @@
     ],
     "status": "employed",
     "graduationDate": "11-08-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 17,
@@ -340,7 +339,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "11-08-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 18,
@@ -364,7 +363,7 @@
     ],
     "status": "employed",
     "graduationDate": "11-08-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 19,
@@ -389,7 +388,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "23-10-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 20,
@@ -414,7 +413,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "23-10-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 21,
@@ -439,7 +438,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "23-10-2019",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 22,
@@ -451,7 +450,7 @@
     "photo": "/static/team/abdulrahman.jpg",
     "linkedin": "https://www.linkedin.com/in/ramadan46/",
     "skills": ["JS", "MySQL", "React", "HTML", "CSS", "Node.js"],
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 23,
@@ -463,7 +462,7 @@
     "photo": "/static/team/zoey.jpg",
     "linkedin": "https://www.linkedin.com/in/zoeyzou2018/",
     "skills": ["JS", "MySQL", "React", "HTML", "CSS", "Node.js"],
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 24,
@@ -475,7 +474,7 @@
     "photo": "/static/team/hala.jpg",
     "linkedin": "https://www.linkedin.com/in/hala-qasim-009451155/",
     "skills": ["JS", "MySQL", "React", "HTML", "CSS", "Node.js"],
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 25,
@@ -498,11 +497,11 @@
       "Knex.js",
       "MySQL",
       "Firebase",
-      "TS"
+      "TypeScript"
     ],
     "status": "looking for jobs",
     "graduationDate": "29-04-2020",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 26,
@@ -530,7 +529,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "29-01-2020",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 27,
@@ -552,11 +551,11 @@
       "Node.js",
       "Python",
       "Knex.js",
-      "sass"
+      "Sass"
     ],
     "status": "looking for jobs",
     "graduationDate": "29-04-2020",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 28,
@@ -573,7 +572,7 @@
       "React",
       "Node.js",
       "Express.js",
-      "Wordpress",
+      "WordPress",
       "PHP",
       "Knex.js",
       "MySQL",
@@ -581,12 +580,12 @@
       "CSS",
       "Sass",
       "Bootstrap",
-      "Adobe package",
+      "Adobe",
       "Git"
     ],
     "status": "looking for jobs",
     "graduationDate": "08-07-2020",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 29,
@@ -616,7 +615,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "29-01-2020",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 30,
@@ -637,15 +636,15 @@
       "HTML",
       "CSS",
       "Node.js",
-      "Typescript",
-      "storybook",
+      "TypeScript",
+      "Storybook",
       "Firebase",
       "Git",
       "Microsoft Azure"
     ],
     "status": "looking for jobs",
     "graduationDate": "29-04-2020",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 31,
@@ -673,7 +672,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "29-04-2020",
-    "lastUpdateDate": "01-09-2020" 
+    "lastUpdateDate": "01-09-2020"
   },
   {
     "id": 32,
@@ -684,13 +683,26 @@
     "github": "https://github.com/rufaidaju",
     "onlineCV": "/static/alumni/cv/rufaida.pdf",
     "linkedin": "https://www.linkedin.com/in/rufaida-jumaa-a15ba4142",
-    "skills": ["JS","React","Node.js","Git","Knex.js","Express.js","MySQL","HTML","CSS","Sitecore","Umbraco","Bootstrap"],
+    "skills": [
+      "JS",
+      "React",
+      "Node.js",
+      "Git",
+      "Knex.js",
+      "Express.js",
+      "MySQL",
+      "HTML",
+      "CSS",
+      "Sitecore",
+      "Umbraco",
+      "Bootstrap"
+    ],
     "status": "looking for jobs",
     "graduationDate": "14-01-2018",
-    "lastUpdateDate": "01-09-2020"    
+    "lastUpdateDate": "01-09-2020"
   },
   {
-    "id": 34,
+    "id": 33,
     "roles": ["alumni"],
     "name": "John Alyazji",
     "email": "john.yazji@gmail.com",
@@ -713,7 +725,7 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "08-07-2020",
-    "lastUpdateDate": "05-09-2020" 
+    "lastUpdateDate": "05-09-2020"
   },
   {
     "id": 34,
@@ -724,10 +736,26 @@
     "github": "https://github.com/myshuker",
     "onlineCV": "/static/alumni/cv/mohammad.pdf",
     "linkedin": "https://www.linkedin.com/in/mohammad-alshoker-365376b8/",
-    "skills": ["JS","React","Node.js","Git","Knex.js","Express.js","MySQL","HTML","CSS","MogoDB","SASS","Heroku","Figma","PLC Programming","Swagger"],
+    "skills": [
+      "JS",
+      "React",
+      "Node.js",
+      "Git",
+      "Knex.js",
+      "Express.js",
+      "MySQL",
+      "HTML",
+      "CSS",
+      "MongoDB",
+      "Sass",
+      "Heroku",
+      "Figma",
+      "PLC Programming",
+      "Swagger"
+    ],
     "status": "looking for jobs",
     "graduationDate": "08-07-2020",
-    "lastUpdateDate": "07-09-2020" 
+    "lastUpdateDate": "07-09-2020"
   },
   {
     "id": 35,
@@ -757,6 +785,6 @@
     ],
     "status": "looking for jobs",
     "graduationDate": "08-07-2020",
-    "lastUpdateDate": "23-09-2020" 
+    "lastUpdateDate": "23-09-2020"
   }
 ]


### PR DESCRIPTION
@benna100 There's quite a bit of noise in this PR because my Text Editor removed the dangling commas on the last line for each object. The actual changes made mostly involve changing spellings (or simply the case used in spelling). I also made some other changes which can be considered quite opinionated. I have listed them below:
- I shortened `Adobe package` to `Adobe` since the word package does not convey additional information.
- I shortened `HighCharts/React-HighCharts` to `HighCharts`.
- One individual had listed both Sass and SCSS among the list of skills. I removed SCSS since it is just a different syntax for Sass.
- I left `SAS` in there since I was not really sure if it was a typo in `Sass` or whether the individual is proficient in the use of the statistical software SAS and had listed it in their list of skills.