### PR TITLE
Fix deployment issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "devDependencies": {
     "prettier": "^1.16.4"
+  },
+  "engines": {
+    "node": "14.x"
   }
 }


### PR DESCRIPTION
The problem seems to be that the older packages do not work with node 16 which is what heroku is using now. This change will set it to node 14.